### PR TITLE
Do not install the config folder in tm_driver

### DIFF
--- a/tm_driver/CMakeLists.txt
+++ b/tm_driver/CMakeLists.txt
@@ -127,7 +127,6 @@ target_link_libraries(tm_driver
 #############
 
 install(DIRECTORY launch DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
-install(DIRECTORY config DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
 
 ## Mark executables and/or libraries for installation
 install(TARGETS tm_driver #tm_hardware_interface


### PR DESCRIPTION
Hello,

When trying to integrate the ros package to an application build in install mode, the build for `tm_driver` failed because it could not install the non existent `config` folder.

Since the folder doesn't exist the install directive can safely be removed.
