### PR TITLE
Remove 'meshes' directory and add 'urdf' directory in CMakeLists.txt

### DIFF
--- a/tm_gazebo/CMakeLists.txt
+++ b/tm_gazebo/CMakeLists.txt
@@ -6,5 +6,5 @@ find_package(catkin REQUIRED)
 
 catkin_package()
 
-install(DIRECTORY config launch rviz meshes models worlds xacro
+install(DIRECTORY config launch rviz urdf models worlds xacro
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})


### PR DESCRIPTION
This PR removes the non-existent meshes directory and adds the urdf directory to the CMakeLists.txt file in the tm_gazebo package.